### PR TITLE
Block `Kurisu` and `Vertex` malware

### DIFF
--- a/src/blacklists/ip.txt
+++ b/src/blacklists/ip.txt
@@ -5,7 +5,7 @@
 # Contribute: https://github.com/Summer-CMS-Vendor-Packages/sc-block-bad-crypto-filter-lists/issues
 # License: GPL-3.0 license
 #
-# Last modified: 17 October 2023
+# Last modified: 18 October 2023
 #
 
 100.116.67.89
@@ -412,6 +412,8 @@
 192.243.61.255
 192.252.209.175
 192.64.119.72
+193.233.193.67
+193.233.193.68
 195.54.174.17
 197.184.176.5
 198.16.51.2


### PR DESCRIPTION
Issue: https://github.com/Summer-CMS-Vendor-Packages/sc-block-bad-crypto-filter-lists/issues/158
